### PR TITLE
fix: move slash command registration to ready handler

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -64,6 +64,15 @@ func readyHandler(b *DiscordBot, oai *OpenAiService, cid string) func(s *discord
 		}
 
 		s.ChannelMessageSend(cid, "Botがログインしました。")
+
+		// スラッシュコマンドの登録
+		_, err := s.ApplicationCommandCreate(s.State.User.ID, "", &discordgo.ApplicationCommand{
+			Name:        "forget",
+			Description: "このチャンネルにおけるBotの記憶を削除します。",
+		})
+		if err != nil {
+			log.Printf("Error: Error happend registering slash command: %v", err)
+		}
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
-
-	"github.com/bwmarrin/discordgo"
 )
 
 func main() {
@@ -64,14 +62,6 @@ func main() {
 	bot.Session.AddHandler(messageCreateHandler(bot, cid, openaisv))
 	bot.Session.AddHandler(forgetCommandHandler(bot))
 	bot.Session.Open()
-	// スラッシュコマンドの登録
-	_, err = bot.Session.ApplicationCommandCreate(bot.Session.State.User.ID, "", &discordgo.ApplicationCommand{
-		Name:        "forget",
-		Description: "このチャンネルにおけるBotの記憶を削除します。",
-	})
-	if err != nil {
-		log.Printf("Error: Error happend registering slash command: %v", err)
-	}
 
 	sigch := make(chan os.Signal, 1)
 	signal.Notify(sigch, os.Interrupt)


### PR DESCRIPTION
## 問題

`Session.Open()` は非同期で実行されるため、呼び出し直後に `bot.Session.State.User.ID` にアクセスすると、Stateがまだ初期化されておらずnil pointer dereferenceが発生していました。

## 修正内容

スラッシュコマンドの登録処理を `readyHandler` 内に移動しました。Readyイベント受信時はStateが確実に初期化されているため、安全にアクセスできます。

## 変更ファイル

- `main.go`: スラッシュコマンド登録処理を削除、不要になったdiscordgoのインポートを削除
- `handler.go`: `readyHandler` 内にスラッシュコマンド登録処理を追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/forget` Discord slash command to clear the bot's memory within a specific channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->