### PR TITLE
fix: skip saving empty API response to history

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -170,6 +170,13 @@ func messageCreateHandler(b *DiscordBot, cid string, oai *OpenAiService) func(s 
 				return
 			}
 			if isErr == false {
+				// APIからの応答が空の場合、履歴に保存せずロールバック
+				if completion.Choices[0].Message.Content == "" {
+					log.Println("Warning: API response is empty, rolling back user message")
+					b.CompletionParams.Messages.Value = b.CompletionParams.Messages.Value[:messagesLenBefore]
+					return
+				}
+
 				// メッセージ履歴に追加
 				b.History.AddMessage(cid, "user", usermassage)
 				// メッセージ履歴に追加


### PR DESCRIPTION
## 問題
#24 の問題への修正
LLMからの応答が空（`content: ""`）の場合でも履歴に保存されてしまい、次回のAPIリクエストで400エラー（`Invalid role: ""`）が発生していました。

## 修正内容

APIからの応答が空の場合、以下の処理を行うようにしました：
- 会話履歴（history.json）に保存しない
- `CompletionParams.Messages` にassistantメッセージを追加しない
- ユーザーメッセージもロールバックして、不完全な会話ペアを残さない

## 変更箇所

`handler.go` の成功パスに空応答チェックを追加：
```go
if completion.Choices[0].Message.Content == "" {
    log.Println("Warning: API response is empty, rolling back user message")
    b.CompletionParams.Messages.Value = b.CompletionParams.Messages.Value[:messagesLenBefore]
    return
}
```